### PR TITLE
fix: ensure download button actually downloads all images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,17 +54,22 @@ export function App() {
     setImages([]);
   }, [images]);
 
-  const handleDownloadAll = useCallback(() => {
-    const completedImages = images.filter(img => img.status === 'complete');
-    completedImages.forEach(image => {
+  const handleDownloadAll = useCallback(async () => {
+    const completedImages = images.filter((img) => img.status === "complete");
+
+    for (let i = 0; i < completedImages.length; i++) {
+      const image = completedImages[i];
+      
       if (image.blob && image.outputType) {
-        const link = document.createElement('a');
+        const link = document.createElement("a");
         link.href = URL.createObjectURL(image.blob);
-        link.download = `${image.file.name.split('.')[0]}.${image.outputType}`;
+        link.download = `${image.file.name.split(".")[0]}.${image.outputType}`;
         link.click();
         URL.revokeObjectURL(link.href);
       }
-    });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
   }, [images]);
 
   const completedImages = images.filter(img => img.status === 'complete').length;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,9 +57,7 @@ export function App() {
   const handleDownloadAll = useCallback(async () => {
     const completedImages = images.filter((img) => img.status === "complete");
 
-    for (let i = 0; i < completedImages.length; i++) {
-      const image = completedImages[i];
-      
+    for (const image of completedImages) {
       if (image.blob && image.outputType) {
         const link = document.createElement("a");
         link.href = URL.createObjectURL(image.blob);


### PR DESCRIPTION
With the current download button functionality, not all images are downloaded. Added a slight delay so all the images are processed smoothly and ensure actually all of them are downloaded.

---

Btw, wouldn't it be better the download button to be disabled until all the images are uploaded? I'm just curious why the condition is just checking if the count is > 0.