### PR TITLE
fix(CompressionOptions): added tabular-nums to label

### DIFF
--- a/src/components/CompressionOptions.tsx
+++ b/src/components/CompressionOptions.tsx
@@ -39,7 +39,7 @@ export function CompressionOptions({
 
       {outputType !== 'png' && (
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-gray-700 mb-2 tabular-nums">
             Quality: {options.quality}%
           </label>
           <input


### PR DESCRIPTION
This PR adds the tabular-nums Tailwind class to labels containing numbers. This improves the alignment of numbers, making the UI cleaner and easier to read. A video comparing the before and after is here


https://github.com/user-attachments/assets/ebef1143-da4d-4599-8899-7ba07b8fa2e2

